### PR TITLE
Add note about reading notes for mini in pixel

### DIFF
--- a/data/nodes/bearaga.yaml
+++ b/data/nodes/bearaga.yaml
@@ -16,5 +16,6 @@ The Desert of Shifting Sands:
     - "When !Released, they hit for ~2200 physical damage, which is kind of a lot in W1."
   Generic:
     - "To get the treasure chests in the Catapult, answer no when you interact with the switch, THEN yes. (Pull, not push.)"
+    - "Pixel: You HAVE TO read the notes before you can pull the switch (first note is in bedroom)."
   INTERSECTION White-Mage Red-Mage:
     - "Make sure you don't miss the !White spell Mini in one of them. You can buy it later, but it's a LOT later."


### PR DESCRIPTION
Saying no to "push the switch" acts as a cancel until you read the notes then you get the option to pull.